### PR TITLE
Fix some CPU tests

### DIFF
--- a/Win32Emu.Tests.Emulator/SingleStepDebugTest.cs
+++ b/Win32Emu.Tests.Emulator/SingleStepDebugTest.cs
@@ -77,7 +77,7 @@ public class SingleStepDebugTest
 		// Execute instruction
 		_output.WriteLine("Executing instruction...");
 		cpu.SingleStep(memory);
-		cpu.SingleStep(memory);
+		cpu.SingleStep(memory); //Execute HLT too.
 		
 		var finalEip = cpu.GetEip();
 		_output.WriteLine($"Final EIP: 0x{finalEip:X8}");

--- a/Win32Emu/Cpu/Iced/IcedCpu.cs
+++ b/Win32Emu/Cpu/Iced/IcedCpu.cs
@@ -1285,7 +1285,7 @@ public class IcedCpu : IAsyncCpu
 		}
 		else
 		{
-			throw new NotImplementedException($"[JitCpu] MOVD with unsupported operand types: {insn.Op0Kind}, {insn.Op1Kind}");
+			throw new NotImplementedException($"[IcedCpu] MOVD with unsupported operand types: {insn.Op0Kind}, {insn.Op1Kind}");
 		}
 	}
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add MMX register support with 8 64-bit registers

- Implement MOVD instruction for MMX register operations

- Fix test by adding missing CPU single-step execution call


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MMX Support Added"] --> B["8 MMX Registers"]
  A --> C["MOVD Instruction Handler"]
  D["Test Fix"] --> E["Extra SingleStep Call"]
  B --> F["ExecMmxMovd Implementation"]
  C --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IcedCpu.cs</strong><dd><code>Add MMX register support and MOVD instruction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Win32Emu/Cpu/Iced/IcedCpu.cs

<ul><li>Added <code>_mmx</code> array to store 8 MMX 64-bit registers<br> <li> Added <code>Mnemonic.Movd</code> case in instruction execution switch<br> <li> Implemented <code>ExecMmxMovd</code> method to handle MOVD instruction with MMX <br>registers<br> <li> Supports both MMX register as destination and source operands</ul>


</details>


  </td>
  <td><a href="https://github.com/archanox/Win32Emu/pull/942/files#diff-c0b2e3b0cf6dc16aa98c544a7cade52a4e23f62e1d810f3507e227b684f10945">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleStepDebugTest.cs</strong><dd><code>Add missing CPU single-step call in test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Win32Emu.Tests.Emulator/SingleStepDebugTest.cs

<ul><li>Added second <code>cpu.SingleStep(memory)</code> call in test execution<br> <li> Ensures proper instruction stepping during test execution</ul>


</details>


  </td>
  <td><a href="https://github.com/archanox/Win32Emu/pull/942/files#diff-71ba453f57d5a76e174b502165d378d7d0185fe5d03b86c3b63dbec12b6c39d0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

Add MMX MOVD instruction support to the CPU emulator and fix a single-step debug test to correctly execute two instructions.

New Features:
- Introduce an MMX register file with eight 64-bit registers in the CPU emulator.
- Support the MOVD instruction for transferring 32-bit values between general operands and MMX registers.

Bug Fixes:
- Correct the single-step debug test to perform an additional CPU SingleStep call so both intended instructions are executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MMX MOVD support for moving data between MMX registers, including correct zero-extension for cross-size transfers.

* **Tests**
  * Enhanced single-step debug test to perform an additional instruction step for finer-grained step validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->